### PR TITLE
Zstream outside ocaml heap

### DIFF
--- a/zlibstubs.c
+++ b/zlibstubs.c
@@ -52,7 +52,6 @@ static void camlzip_error(char * fn, value vzs)
   caml_raise(bucket);
 }
 
-#include <stdio.h>
 void camlzip_free_stream(value vzs)
 {
   free(ZStream_val(vzs));


### PR DESCRIPTION
Use malloc'ed data in a custom wrapper to avoid reallocating the structure (fixes #1)