### PR TITLE
Don't treat Z_BUF_ERROR as a fatal error

### DIFF
--- a/zlibstubs.c
+++ b/zlibstubs.c
@@ -105,7 +105,7 @@ value camlzip_deflate(value vzs, value srcbuf, value srcpos, value srclen,
   zs->next_out = &Byte_u(dstbuf, Long_val(dstpos));
   zs->avail_out = Long_val(dstlen);
   retcode = deflate(zs, camlzip_flush_table[Int_val(vflush)]);
-  if (retcode < 0) camlzip_error("Zlib.deflate", vzs);
+  if (retcode < 0 && retcode != Z_BUF_ERROR) camlzip_error("Zlib.deflate", vzs);
   used_in = Long_val(srclen) - zs->avail_in;
   used_out = Long_val(dstlen) - zs->avail_out;
   zs->next_in = NULL;         /* not required, but cleaner */
@@ -153,7 +153,7 @@ value camlzip_inflate(value vzs, value srcbuf, value srcpos, value srclen,
   zs->next_out = &Byte_u(dstbuf, Long_val(dstpos));
   zs->avail_out = Long_val(dstlen);
   retcode = inflate(zs, camlzip_flush_table[Int_val(vflush)]);
-  if (retcode < 0 || retcode == Z_NEED_DICT)
+  if ((retcode < 0 && retcode != Z_BUF_ERROR) || retcode == Z_NEED_DICT)
     camlzip_error("Zlib.inflate", vzs);
   used_in = Long_val(srclen) - zs->avail_in;
   used_out = Long_val(dstlen) - zs->avail_out;


### PR DESCRIPTION
Previously Z_BUF_ERROR error code was treated as fatal and it raised an exception in OCaml. However the error is not fatal according to zlib documentation [1].

Handling this is necessary for streaming compression where you never finish the stream with Z_FINISH.

Seems like ignoring the error is sufficient as returned values for used_in and used_out will be 0 in case it happens.

Documentation says:
"this is simply an indication that deflate() could not consume more input or produce more output. deflate() can be called again with more output space or more available input, which it will be in this code."

[1] https://zlib.net/zlib_how.html