### PR TITLE
Alias camlzip to zip

### DIFF
--- a/META-camlzip
+++ b/META-camlzip
@@ -1,6 +1,1 @@
-version="1.07"
-requires="unix"
-archive(byte)="zip.cma"
-archive(native)="zip.cmxa"
-archive(native,plugin)="zip.cmxs"
-directory="../zip"
+requires="zip"


### PR DESCRIPTION
The current META setup breaks when both zip and camlzip are used in the same
build with warning 31 enabled. After this fix, warning 31 no longer affects this.

Simplest way to reproduce this is to compile some file with:

```
$ ocamlfind ocamlc -package camlzip,zip -linkall -linkpkg x.ml -w +31 -o x.byte
File "x.ml", line 2, characters 16-32:
Warning 5: this function application is partial,
maybe some arguments are missing.
File "/home/rgrinberg/.opam/4.05.0/lib/zip/zip.cma(Zlib)", line 1:
Warning 31: files /home/rgrinberg/.opam/4.05.0/lib/zip/zip.cma(Zlib) and
/home/rgrinberg/.opam/4.05.0/lib/camlzip/../zip/zip.cma(Zlib) both define a
module named Zlib
File "/home/rgrinberg/.opam/4.05.0/lib/zip/zip.cma(Zip)", line 1:
Warning 31: files /home/rgrinberg/.opam/4.05.0/lib/zip/zip.cma(Zip) and
/home/rgrinberg/.opam/4.05.0/lib/camlzip/../zip/zip.cma(Zip) both define a
module named Zip
File "/home/rgrinberg/.opam/4.05.0/lib/zip/zip.cma(Gzip)", line 1:
Warning 31: files /home/rgrinberg/.opam/4.05.0/lib/zip/zip.cma(Gzip) and
/home/rgrinberg/.opam/4.05.0/lib/camlzip/../zip/zip.cma(Gzip) both define a
module named Gzip
File "x.ml", line 1:
Error: Some fatal warnings were triggered (3 occurrences)
```