### PR TITLE
Add a gitignore file for build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+*.a
+*.cma
+*.cmi
+*.cmo
+*.o
+*.so
+
+test/minigzip
+test/minizip


### PR DESCRIPTION
This ignores all of the files that were created when I ran:

```
make
cd test
make
```

This helps avoid accidentally checking them in, and also improves the editor experience, since most editors hide ignores files.