### PR TITLE
Zip in channel

### DIFF
--- a/zip.ml
+++ b/zip.ml
@@ -231,7 +231,9 @@ let open_in_channel ?(filename="") ic =
 
 let open_in filename =
   let ic = Pervasives.open_in_bin filename in
-  open_in_channel ~filename ic
+  let ifile = open_in_channel ~filename ic in
+  Pervasives.close_in ic;
+  ifile
 
 (* Close a ZIP file opened for reading *)
 

--- a/zip.ml
+++ b/zip.ml
@@ -217,8 +217,7 @@ let read_cd filename ic cd_entries cd_offset cd_bound =
 
 (* Open a ZIP file for reading *)
 
-let open_in filename =
-  let ic = Pervasives.open_in_bin filename in
+let open_in_channel ?(filename="") ic =
   let (cd_entries, cd_size, cd_offset, cd_comment) = read_ecd filename ic in
   let entries =
     read_cd filename ic cd_entries cd_offset (Int32.add cd_offset cd_size) in
@@ -229,6 +228,10 @@ let open_in filename =
     if_entries = entries;
     if_directory = dir;
     if_comment = cd_comment }
+
+let open_in filename =
+  let ic = Pervasives.open_in_bin filename in
+  open_in_channel ~filename ic
 
 (* Close a ZIP file opened for reading *)
 

--- a/zip.mli
+++ b/zip.mli
@@ -57,6 +57,10 @@ type in_file
 val open_in: string -> in_file
           (** Open the ZIP file with the given filename.  Return a
               handle opened for reading from this file. *)
+val open_in_channel: ?filename:string -> Pervasives.in_channel -> in_file
+          (** Open the ZIP file in the given [in_channel]. Return a handle
+              opened for reading from this file. [filename] is used for
+              debug purposes. *)
 val entries: in_file -> entry list
           (** Return a list of all entries in the given ZIP file. *)
 val comment: in_file -> string


### PR DESCRIPTION
This lets us read zip files that aren't on the file system.

In particular, I want to be able to unzip files that I'm already holding in memory, and pushing them through a pipe is better than having to write to a temp file. Ideally I wouldn't need an `in_channel` at all, but taking a string as an input would be a lot more changes.  