### PR TITLE
Zlib.compress_direct should call deflate_end

### DIFF
--- a/zlib.ml
+++ b/zlib.ml
@@ -87,6 +87,7 @@ let compress_direct  ?(level = 6) ?(header = true) flush =
                  outbuf 0 buffer_size Z_FINISH in
     flush outbuf used_out;
     if not finished then compr_finish()
+    else deflate_end zs
   in
   compr, compr_finish
 


### PR DESCRIPTION
Contrary to `Zlib.compress`, `Zlib.compress_direct` never calls `deflate_end`, which leads to memory leaks.  This also impacts `Zip.add_entry_generator`.