### PR TITLE
Add a `flush_continue` function

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,6 @@
+Unreleased:
+- Add a flush_continue function to allow flushing to disk then continuing
+
 Release 1.08:
 - ocamlfind is now mandatory as a consequence of GPR#4
 - GPR#4: use ocamlfind and $(EXT_...) configuration variables for better

--- a/gzip.mli
+++ b/gzip.mli
@@ -119,9 +119,9 @@ val flush: out_channel -> unit
            channel.  This can be useful if e.g. the underlying file channel
            is a network socket on which more data is to be sent. *)
 val flush_continue: out_channel -> unit
-       (** Flush data data through both the compression channel and the
-           underlying regular file channel, but keep both channels open to
-           accept further data. *)
+       (** Flush all pending compressed data through both the compression
+           channel and the underlying regular file channel, but keep both
+           channels open to accept further data. *)
 
 (** {6 Error reporting} *)
 

--- a/gzip.mli
+++ b/gzip.mli
@@ -69,7 +69,7 @@ val dispose: in_channel -> unit
            regular file channel (of type [Pervasives.in_channel]);
            just dispose of the resources associated with the decompression
            channel.  This can be useful if e.g. the underlying file channel
-           is a network socket on which more (uncompressed) data 
+           is a network socket on which more (uncompressed) data
            is expected. *)
 
 (** {6 Writing to compressed files} *)
@@ -80,7 +80,7 @@ type out_channel
 val open_out: ?level:int -> string -> out_channel
        (** Open a compressed file for writing.  The argument is the file
            name.  The file is created if it does not exist, or
-           truncated to zero length if it exists. 
+           truncated to zero length if it exists.
            The optional [level] argument (an integer between 1 and 9)
            indicates the compression level, with 1 being the weakest
            (but fastest) compression and 9 being the strongest
@@ -118,6 +118,10 @@ val flush: out_channel -> unit
            dispose of the resources associated with the compression
            channel.  This can be useful if e.g. the underlying file channel
            is a network socket on which more data is to be sent. *)
+val flush_continue: out_channel -> unit
+       (** Flush data data through both the compression channel and the
+           underlying regular file channel, but keep both channels open to
+           accept further data. *)
 
 (** {6 Error reporting} *)
 


### PR DESCRIPTION
Fixes #21

This PR adds a new `flush_continue` function that allows the user to flush the contents of the zip buffer all the way to disk but then continue writing to the zipped channel.

I haven't added any testing, but I'm happy to add any that would be useful. In particular, I am slightly concerned that the `out_size` and `out_crc` variable should be updated as part of the flush procedure, but the existing `flush` function does not do that so maybe it is fine.