### PR TITLE
Fixup flush_continue command to use the correct flush method

### DIFF
--- a/test/minigzip.ml
+++ b/test/minigzip.ml
@@ -28,6 +28,6 @@ let _ =
     let oc = Gzip.open_out_chan stdout in
     let rec compress () =
       let n = input stdin buffer 0 (Bytes.length buffer) in
-      if n = 0 then () else begin Gzip.output oc buffer 0 n; compress() end
+      if n = 0 then () else begin Gzip.output oc buffer 0 n; Gzip.flush_continue oc; compress() end
     in compress(); Gzip.flush oc
   end


### PR DESCRIPTION
This MR fixes up the new `flush_continue` method to use the `FLUSH_SYNC` setting rather than the `FINAL` setting (which meant that the Zlib instance could not be reused after running `flush_continue`.

I have also updated `minigzip.ml` to use `flush_continue` in order to give the function a bit more exposure - I am happy to add more testing if required.