### PR TITLE
Call inflateEnd / deflateEnd in finalizers

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,7 +1,10 @@
+- #41, #42: fix memory leak when a `Zlib.stream` is finalized and
+  `Zlib.deflate_end` / `Zlib.inflate_end` was not called before
+
 Release 1.11:
 - `Zip.add_entry_generator ~level:0` was missing a CRC update
-- GPR#28: fix build on platforms with no shared libs
-- GPR#33: update META files to use plugin convention
+- #28: fix build on platforms with no shared libs
+- #33: update META files to use plugin convention
 - Use `Stdlib.xxx` instead of `Pervasives.xxx`.  OCaml >= 4.07 is required.
 - `make all` automatically builds in native-code if supported
 - Added local .opam file
@@ -9,29 +12,29 @@ Release 1.11:
 - Generate and install .mli, .cmt, and .cmti files
 
 Release 1.10:
-- GPR#25: Fix Gzip.flush_continue [James Owen]
+- #25: Fix Gzip.flush_continue [James Owen]
 - Improve compatibility with OCaml 4.09
 
 Release 1.09:
-- GPR#22: Add a Gzip.flush_continue function that allows the user to
+- #22: Add a Gzip.flush_continue function that allows the user to
   flush the contents of the zip buffer all the way to disk but then
   continue writing to the zipped channel  [James Owen]
 
 Release 1.08:
-- ocamlfind is now mandatory as a consequence of GPR#4
-- GPR#4: use ocamlfind and $(EXT_...) configuration variables for better
+- ocamlfind is now mandatory as a consequence of #4
+- #4: use ocamlfind and $(EXT_...) configuration variables for better
   cross-platform support in Makefile [user 'whitequark']
 - Improve Mingw support in Makefile (install .dll files) [Bertrand Jeannet]
-- GPR#5: make sure 'zip' and 'camlzip' packages can be used both in the
+- #5: make sure 'zip' and 'camlzip' packages can be used both in the
   same executable [Rudi Grinberg]
-- GPR#6: Z_BUF_ERROR is not a fatal error, just a transient condition
+- #6: Z_BUF_ERROR is not a fatal error, just a transient condition
   [Tuukka Korhonen]
-- GPR#13: fix memory leak in Zlib.compress_direct [Alain Frisch]
-- GPR#14: add Zlib.deflate_string and Zlib.inflate_string, using immutable
+- #13: fix memory leak in Zlib.compress_direct [Alain Frisch]
+- #14: add Zlib.deflate_string and Zlib.inflate_string, using immutable
   strings as input buffers instead of mutable bytes [Vincent Balat]
-- GPR#16: assertion failure when reading ZIP files with 2^16 entries or more
+- #16: assertion failure when reading ZIP files with 2^16 entries or more
   [Einar Lielmanis]
-- GPR#18: in Zip.open_in, properly close channels in case of error
+- #18: in Zip.open_in, properly close channels in case of error
   [Daniel Weil]
 
 Release 1.07:

--- a/zlibstubs.c
+++ b/zlibstubs.c
@@ -69,11 +69,10 @@ value camlzip_deflateInit(value vlevel, value expect_header)
     caml_alloc_custom_mem(&camlzip_dstream_ops,
                           sizeof(z_streamp), sizeof(z_stream));
   ZStream_val(vzs) = caml_stat_alloc(sizeof(z_stream));
+  /* Zlib API: the fields zalloc, zfree and opaque must be initialized */
   ZStream_val(vzs)->zalloc = NULL;
   ZStream_val(vzs)->zfree = NULL;
   ZStream_val(vzs)->opaque = NULL;
-  ZStream_val(vzs)->next_in = NULL;
-  ZStream_val(vzs)->next_out = NULL;
   if (deflateInit2(ZStream_val(vzs),
                    Int_val(vlevel),
                    Z_DEFLATED,
@@ -142,12 +141,14 @@ value camlzip_inflateInit(value expect_header)
   value vzs =
     caml_alloc_custom_mem(&camlzip_istream_ops,
                           sizeof(z_streamp), sizeof(z_stream));
+  /* Zlib API: The fields next_in, avail_in, zalloc, zfree and opaque
+     must be initialized */
   ZStream_val(vzs) = caml_stat_alloc(sizeof(z_stream));
   ZStream_val(vzs)->zalloc = NULL;
   ZStream_val(vzs)->zfree = NULL;
   ZStream_val(vzs)->opaque = NULL;
   ZStream_val(vzs)->next_in = NULL;
-  ZStream_val(vzs)->next_out = NULL;
+  ZStream_val(vzs)->avail_in = 0;
   if (inflateInit2(ZStream_val(vzs),
                    Bool_val(expect_header) ? MAX_WBITS : -MAX_WBITS) != Z_OK)
     camlzip_error("Zlib.inflateInit", vzs);


### PR DESCRIPTION
Otherwise, a memory leak occurs if `Zlib.deflate_end` / `Zlib.inflate_end` were not called before the `Zlib.stream` became unreachable.

Also: use `caml_alloc_custom_mem` instead of `caml_alloc_custom`.

Fixes: #41