### PR TITLE
Full support for ZIP64 archives

### DIFF
--- a/test/bigfiles.run
+++ b/test/bigfiles.run
@@ -1,0 +1,33 @@
+#!/bin/sh
+
+here=`pwd`
+
+tempdir="$1"
+if [ -z "$tempdir" ]; then
+  echo "Usage: bigfiles.run <tempdir>" 1>&2
+  echo "<tempdir> must have 10 Gb of free space" 1>&2
+  exit 2
+fi
+
+cd $tempdir
+
+trap "rm -f zeroes" 0 EXIT INT
+
+echo "Creating big file..."
+dd if=/dev/zero of=zeroes bs=1000000 count=5120
+echo "Running the tests..."
+
+runtest() {
+  rm -rf result minizip.zip
+  mkdir result
+  if ($2 ./minizip.zip zeroes > /dev/null && \
+     (cd result && $3 ../minizip.zip > /dev/null) && \
+     cmp result/zeroes zeroes)
+  then rm -rf result minizip.zip; echo "$1: passed"
+  else rm -rf result minizip.zip; echo "$1: FAILED"; exit 2
+  fi
+}
+
+runtest "Big file 1" "$here/minizip c" "$here/minizip x"
+runtest "Big file 2" "zip -r" "$here/minizip x"
+runtest "Big file 3" "$here/minizip c" "unzip"

--- a/test/manyfiles.run
+++ b/test/manyfiles.run
@@ -1,0 +1,44 @@
+#!/bin/sh
+
+here=`pwd`
+
+tempdir="$1"
+if [ -z "$tempdir" ]; then
+  echo "Usage: manyfiles.run <tempdir>" 1>&2
+  echo "<tempdir> must have 10 Gb of free space" 1>&2
+  exit 2
+fi
+
+cd $tempdir
+
+trap "rm -rf hier" 0 EXIT INT
+
+echo "Creating file hierarchy..."
+rm -rf hier
+mkdir hier hier/1
+j=1
+while [ $j -le 300 ]; do
+  dd if=/dev/zero of=hier/1/$j bs=50000 count=1 status=none
+  j=`expr $j + 1`
+done
+i=2
+while [ $i -le 300 ]; do
+  ln -s 1 hier/$i
+  i=`expr $i + 1`
+done
+echo "Running the tests..."
+
+runtest() {
+  rm -rf result minizip.zip
+  mkdir result
+  if ($2 ./minizip.zip hier > /dev/null && \
+     (cd result && $3 ../minizip.zip > /dev/null) && \
+     diff -q -r result/hier hier)
+  then rm -rf result minizip.zip; echo "$1: passed"
+  else rm -rf result minizip.zip; echo "$1: FAILED"; exit 2
+  fi
+}
+
+runtest "Many files 1" "$here/minizip c" "$here/minizip x"
+runtest "Many files 2" "zip -r" "$here/minizip x"
+runtest "Many files 3" "$here/minizip c" "unzip"

--- a/zip.mli
+++ b/zip.mli
@@ -31,13 +31,12 @@
 (** {1 Information on ZIP entries} *)
 
 type compression_method =
-    Stored                     (** data is stored without compression *)
+  | Stored                     (** data is stored without compression *)
   | Deflated                   (** data is compressed with the ``deflate'' algorithm *)
         (** Indicate whether the data in the entry is compressed or not. *)
 
 type entry =
   { filename: string;          (** file name for entry *)
-    extra: string;             (** extra information attached to entry *)
     comment: string;           (** comment attached to entry *)
     methd: compression_method; (** compression method *)
     mtime: float;              (** last modification time (seconds since epoch) *)
@@ -105,8 +104,8 @@ val open_out: ?comment: string -> string -> out_file
               ZIP entries). *) 
 val add_entry:
   string -> out_file -> 
-    ?extra: string -> ?comment: string -> ?level: int ->
-    ?mtime: float -> string -> unit
+    ?comment: string -> ?level: int -> ?mtime: float ->
+    string -> unit
           (** [Zip.add_entry data zf name] adds a new entry to the 
               ZIP file [zf].  The data (file contents) associated with
               the entry is taken from the string [data].  It is compressed
@@ -114,8 +113,6 @@ val add_entry:
               stored along with this entry.  Several optional arguments
               can be provided to control the format and attached information 
               of the entry:
-              @param extra  extra data attached to the entry (a string).
-                Default: empty.
               @param comment  attached to the entry (a string).
                 Default: empty.
               @param level  compression level for the entry.  This is an
@@ -129,15 +126,15 @@ val add_entry:
                 Default: the current time. *)
 val copy_channel_to_entry:
   in_channel -> out_file -> 
-    ?extra: string -> ?comment: string -> ?level: int ->
-    ?mtime: float -> string -> unit
+    ?comment: string -> ?level: int -> ?mtime: float ->
+    string -> unit
           (** Same as [Zip.add_entry], but the data associated with the
               entry is read from the input channel given as first argument.
               The channel is read up to end of file. *)
 val copy_file_to_entry:
   string -> out_file -> 
-    ?extra: string -> ?comment: string -> ?level: int ->
-    ?mtime: float -> string -> unit
+    ?comment: string -> ?level: int -> ?mtime: float ->
+    string -> unit
           (** Same as [Zip.add_entry], but the data associated with the
               entry is read from the file whose name is given as first
               argument.  Also, the default value for the [mtime]
@@ -145,8 +142,8 @@ val copy_file_to_entry:
               file. *)
 val add_entry_generator:
   out_file ->
-    ?extra: string -> ?comment: string -> ?level: int ->
-    ?mtime: float -> string -> (bytes -> int -> int -> unit) * (unit -> unit)
+    ?comment: string -> ?level: int -> ?mtime: float -> 
+    string -> (bytes -> int -> int -> unit) * (unit -> unit)
           (** [Zip.add_entry_generator zf name] returns a pair of functions
               [(add, finish)].  It adds a new entry to the 
               ZIP file [zf].  The file name stored along with this entry


### PR DESCRIPTION
This PR builds on #39 and adds support for individual files larger than 4 Gib and for archives containing more than 65535 files, both for reading and for writing.

The new code to handle large files or large archives was lightly tested against Info-Zip (`zip` and `unzip` under Linux).

For small files and small archives, the only change is in how files are added to ZIP archives in write mode: instead of adding a data descriptor after the file data (it is unclear how to do this correctly for files larger than 4 Gib), we patch the local file header with the final sizes and CRC.  The latter is what Info-Zip does, apparently.

Tiny change in the API: the "extra" data attached to files used to be exposed as a string in the `entry` record and as arguments to the `add` functions.  This was not quite right, since this data is actually a list of (tag, data) blocks.  For simplicity, this PR removes the "extra" field and optional arguments from the API.  

Closes: #35
