### PR TITLE
Validate and normalize file name when adding entries to ZIP files

### DIFF
--- a/zip.ml
+++ b/zip.ml
@@ -588,8 +588,14 @@ let add_entry_header ofile comment level mtime filename =
     raise(Error(ofile.of_filename, filename, "wrong compression level"));
   if String.length filename >= 0x10000 then
     raise(Error(ofile.of_filename, filename, "filename too long"));
+  if not (Filename.is_relative filename) then
+    raise(Error(ofile.of_filename, filename, "file name must not be absolute"));
   if String.length comment >= 0x10000 then
     raise(Error(ofile.of_filename, filename, "comment too long"));
+  let filename =
+    if Sys.os_type = "Win32"   (* normalize directory separators *)
+    then String.map (function '\\' -> '/' | c -> c) filename
+    else filename in
   let oc = ofile.of_channel in
   let pos = LargeFile.pos_out oc in
   write4 oc 0x04034b50l;                (* signature *)

--- a/zip.mli
+++ b/zip.mli
@@ -110,9 +110,10 @@ val add_entry:
               ZIP file [zf].  The data (file contents) associated with
               the entry is taken from the string [data].  It is compressed
               and written to the ZIP file [zf].  [name] is the file name
-              stored along with this entry.  Several optional arguments
-              can be provided to control the format and attached information 
-              of the entry:
+              stored along with this entry. 
+
+              Several optional arguments can be provided to control
+              the format and attached information of the entry:
               @param comment  attached to the entry (a string).
                 Default: empty.
               @param level  compression level for the entry.  This is an
@@ -123,7 +124,12 @@ val add_entry:
                 Default: 6 (moderate compression).
               @param mtime  last modification time (in seconds since the
                 epoch).
-                Default: the current time. *)
+                Default: the current time.
+
+              Under Windows, backslash characters [\] in the [name] parameter
+              are stored in the ZIP file as forward slashes [/], for
+              compatibility with other operating systems. *)
+
 val copy_channel_to_entry:
   in_channel -> out_file -> 
     ?comment: string -> ?level: int -> ?mtime: float ->


### PR DESCRIPTION
- The ZIP specification says that forward slashes must be used instead of backslashes in file names.  Transform `\` to `/` under Windows and reject `\` in file names on other systems.

- Also check that the file name is not absolute.

Fixes: #40 .
