### PR TITLE
Adds another example (OCaml Examples Project)

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ See the comments in files zip.mli and gzip.mli.  Alternatively, do `make doc` an
 Compilation:      `ocamlfind ocamlopt -package zip ...`
 Linking:          `ocamlfind ocamlopt -package zip -linkpgk ...`
 
-The directory test/ contains examples of using this library.
+The directories example/ and test/ contain examples of using this library.
 
 ## LICENSING
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,19 @@
+# camlzip
+
+This example is for the camlzip library
+
+https://opam.ocaml.org/packages/camlzip
+
+# Source file
+
+`bin/main.ml`
+
+# Building and running
+
+`dune exec bin/main.exe [zlibcompress ... | zlibuncompress ... | zipfiles ... | ziplist]`
+
+(See source for details.)
+
+# Cleaning up
+
+`dune clean`

--- a/examples/README.md
+++ b/examples/README.md
@@ -10,7 +10,10 @@ https://opam.ocaml.org/packages/camlzip
 
 # Building and running
 
-`dune exec bin/main.exe [zlibcompress ... | zlibuncompress ... | zipfiles ... | ziplist]`
+`dune exec bin/main.exe zlibcompress infile compressed-outfile`
+`dune exec bin/main.exe zlibuncompress compressed-infile outfile`
+`dune exec bin/main.exe zipfiles archive-outfile infile1 ... infileN`
+`dune exec bin/main.exe ziplist archive-outfile`
 
 (See source for details.)
 

--- a/examples/bin/dune
+++ b/examples/bin/dune
@@ -1,0 +1,3 @@
+(executable
+ (name main)
+ (libraries camlzip))

--- a/examples/bin/main.ml
+++ b/examples/bin/main.ml
@@ -6,19 +6,13 @@
 
 (* Load a file as a string *)
 let contents_of_file filename =
-  let ch = open_in_bin filename in
-    try
-      let s = really_input_string ch (in_channel_length ch) in
-        close_in ch;
-        s
-    with
-      e -> close_in ch; raise e
+  In_channel.(with_open_bin filename input_all)
 
 (* The compress and uncompress functions take input as available, and produce
 output when available. We pass two functions, one to return the amount of input
 data required, one to write output data as produced. *)
-let f_zlib_in fh_in b = input fh_in b 0 (Bytes.length b)
-let f_zlib_out fh_out b l = output fh_out b 0 l
+let f_zlib_in fh_in b = In_channel.input fh_in b 0 (Bytes.length b)
+let f_zlib_out fh_out b l = Out_channel.output fh_out b 0 l
 
 (* Compress data using raw zlib. *)
 let zlib_compress filename_in filename_out =

--- a/examples/bin/main.ml
+++ b/examples/bin/main.ml
@@ -1,0 +1,63 @@
+(* CamlZip Zlib and Zip examples *)
+
+(* Camlzip comes with large examples in the tests directory, which show much
+   more complete code for Zip and GZip. Here, we give simplistic ones for
+   experimenting with. *)
+
+(* Load a file as a string *)
+let contents_of_file filename =
+  let ch = open_in_bin filename in
+    try
+      let s = really_input_string ch (in_channel_length ch) in
+        close_in ch;
+        s
+    with
+      e -> close_in ch; raise e
+
+(* The compress and uncompress functions take input as available, and produce
+output when available. We pass two functions, one to return the amount of input
+data required, one to write output data as produced. *)
+let f_zlib_in fh_in b = input fh_in b 0 (Bytes.length b)
+let f_zlib_out fh_out b l = output fh_out b 0 l
+
+(* Compress data using raw zlib. *)
+let zlib_compress filename_in filename_out =
+  let fh_in = open_in_bin filename_in in
+  let fh_out = open_out_bin filename_out in
+    Zlib.compress (f_zlib_in fh_in) (f_zlib_out fh_out);
+    close_in fh_in;
+    close_out fh_out
+
+(* Uncompress raw zlib data *)
+let zlib_uncompress filename_in filename_out =
+  let fh_in = open_in_bin filename_in in
+  let fh_out = open_out_bin filename_out in
+    Zlib.uncompress (f_zlib_in fh_in) (f_zlib_out fh_out);
+    close_in fh_in;
+    close_out fh_out
+
+(* Zip some files into a .zip file *)
+let zip_files filename_out filenames_in =
+  let zip = Zip.open_out filename_out in
+    List.iter
+      (fun filename_in ->
+         Zip.add_entry (contents_of_file filename_in) zip filename_in)
+      filenames_in;
+    Zip.close_out zip
+
+(* List the entries in a zip file *)
+let zip_list filename_in =
+  let zip = Zip.open_in filename_in in
+    List.iter
+      (fun {Zip.filename; Zip.uncompressed_size; Zip.compressed_size; _} ->
+        Printf.printf "File %s, %i bytes (originally %i bytes)\n" filename compressed_size uncompressed_size)
+      (Zip.entries zip);
+    Zip.close_in zip
+
+let () =
+  match Array.to_list Sys.argv with
+  | [_; "zlibcompress"; filename_in; filename_out] -> zlib_compress filename_in filename_out
+  | [_; "zlibuncompress"; filename_in; filename_out] -> zlib_uncompress filename_in filename_out
+  | _::"zipfiles"::filename_out::filenames_in -> zip_files filename_out filenames_in
+  | [_; "ziplist"; filename_in] -> zip_list filename_in
+  | _ -> Printf.eprintf "camlzip example: unknown command line\n"

--- a/examples/dune-project
+++ b/examples/dune-project
@@ -1,0 +1,2 @@
+(lang dune 3.14)
+(name camlzip_example)

--- a/examples/dune-workspace
+++ b/examples/dune-workspace
@@ -1,0 +1,2 @@
+(lang dune 3.14)
+(env (dev (flags :standard -warn-error -A)))


### PR DESCRIPTION
This pull request adds another example to CamlZip. This is part of a pilot programme funded by the OCaml Software Foundation.

Many OCaml libraries have no examples, or perfunctory examples only. This makes it difficult to get started with a library, particularly if it has an elaborate interface. A working example, no matter how small, can help a newcomer get started quickly. One day, it would be nice to have an example for every Opam package.

For now, examples begin in the OCaml Nursery, here: https://github.com/johnwhitington/ocaml-nursery  (you can read in the README there about the principles behind these examples.) Then, if package authors agree, they are promoted to upstream source. The hope is that this will mean they are more likely to be kept up to date with the library.

The examples are included in a separate directory, within a separate Dune workspace. And so they are intended to be used after installation of the library.

As well as considering accepting this pull request, please do give any comments you have on this programme.

[The above is boilerplate text. In respect of CamlZip there is at least one obvious inadequacy. The examples use Dune, which doesn't match CamlZip. That's why I've put them in a separate `examples` directory, rather than adding them to the `tests` directory. Not ideal, but not clear what a better solution would be.]