### PR TITLE
Fix general purpose flag and 64bit sizes in local file headers.

### DIFF
--- a/zip.ml
+++ b/zip.ml
@@ -548,7 +548,7 @@ let write_directory_entry oc e =
   let version = match e.methd with Stored -> 10 | Deflated -> 20 in
   write2 oc version;                    (* version made by *)
   write2 oc version;                    (* version needed to extract *)
-  write2 oc 8;                          (* flags *)
+  write2 oc 0;                          (* flags *)
   write2 oc (match e.methd with Stored -> 0 | Deflated -> 8); (* method *)
   let (time, date) = dostime_of_unixtime e.mtime in
   write2 oc time;                       (* last mod time *)
@@ -650,8 +650,8 @@ let add_entry_header ofile comment level mtime filename =
   write2 oc (String.length filename);   (* filename length *)
   write2 oc 20;                         (* extra length *)
   writestring oc filename;              (* filename *)
-  write2 oc 0x0001;                     (* extra data - header ID *)
-  write2 oc 16;                         (* payload size *)
+  write2 oc 0x0000;                     (* extra data - header ID *)
+  write2 oc 0;                          (* payload size *)
   write8 oc 0L;                         (* compressed size - later *)
   write8 oc 0L;                         (* uncompressed size - later *)
   { filename = filename;
@@ -680,7 +680,9 @@ let update_entry ofile crc compr_size uncompr_size entry =
   if overflow then begin
     LargeFile.seek_out oc
       Int64.(add entry.file_offset
-                 (of_int (30 + String.length entry.filename + 4)));
+               (of_int (30 + String.length entry.filename)));
+    write2 oc 0x0001;                     (* extra data - header ID *)
+    write2 oc 16;                         (* payload size *)
     write8 oc csz;                        (* compressed size *)
     write8 oc usz                         (* uncompressed size *)
   end;


### PR DESCRIPTION
Hello,

The 7z utility reports lots of "Headers error" messages when decompressing a zip archive generated with camlzip.

For each file entry of a zip archive, the "General purpose bit flag" is stored at bytes 7 and 8 of local file headers and at bytes 9 and 10 of the central directory file headers. The flag in central directory file headers seems correct (0x00) but the flag stored in local file headers is 0x08 and triggers a "Headers error" message for each file. I suggest to store the flag 0x00 in all local file headers.

Moreover, the extra data stored in local file headers starts with 0x01 0x00 but effectively contains 64 bit sizes only if the file size is greater than 4GiB. In other cases, sizes are not initialized (I mean initialized to 0) and this triggers another "Header errors". As you can see in this pull request, I suggest to initialize the extra data header with 0x01 0x00 only when 64 bit sizes are registered.

With these two modifications, all 7z messages disappear.

Thanks,
Benoît.
